### PR TITLE
OCaml 5 compatibility: Replace Pervasives with Stdlib

### DIFF
--- a/examples/mlgmp/creal.ml
+++ b/examples/mlgmp/creal.ml
@@ -709,7 +709,7 @@ let of_string s base =
     end
   with Invalid_argument _ -> invalid_arg "Creal.of_string"
 
-let flog = Pervasives.log
+let flog = Stdlib.log
 
 let to_string_aux x p = 
   if p < 0 then invalid_arg "Creal.to_string";

--- a/examples/mlgmp/test_mlgmp.ml
+++ b/examples/mlgmp/test_mlgmp.ml
@@ -5,7 +5,7 @@ open Format
 let rng=RNG.randinit (RNG.GMP_RAND_ALG_LC 100);;
 
 let random_matrix l c =
-  let a = Array.create_matrix l c F.zero in
+  let a = Array.make_matrix l c F.zero in
   for i=0 to pred l
   do
     for j=0 to pred c
@@ -21,7 +21,7 @@ let matrix_mul a b =
   and l' = Array.length b
   and n = Array.length b.(0) in
   assert (l = l');
-  let c = Array.create_matrix m n F.zero in
+  let c = Array.make_matrix m n F.zero in
   for i=0 to pred m
   do
     for j=0 to pred n


### PR DESCRIPTION
Since OCaml 4.07 (released 2018-07-10) the always-loaded standard library module has been called Stdlib.  The old Pervasives module was finally removed in OCaml 5.

Array.create_matrix was deprecated in favor of Array.matrix.